### PR TITLE
Bump phpunit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "email": "support@alt-design.net"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-json": "*",
         "ext-curl": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         }
     ],
     "support": {
-        "email": "support@alt-desgin.net"
+        "email": "support@alt-design.net"
     },
     "require": {
         "php": "^8.2",
@@ -19,7 +19,7 @@
         "stripe/stripe-php": "^17.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11",
+        "phpunit/phpunit": "^12.5.22|^13.1.6",
         "mockery/mockery": "^1",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-mockery": "^2.0",


### PR DESCRIPTION
Looks like the tests have been failing for a little while? I've ran them locally with the original phpunit version vs the new versions and same failures. Checked previous PRs and it looks like tests were failing there too but the logs have since expired.

I can't see this harming anything as it's only a dev dependency?